### PR TITLE
Slack notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Put `turnoffall` and `turnonall` into cron with appropriate schedule configs.
 These environment variables need to be specified:
 - `GCP_PROJECT_ID` - project ID (name, not numeric)
 - `GCP_ZONE` - compute zone such as europe-west1-d
+
+If you wish to add Slack notifications for on/off actions, you'll need to specify another environment variable:
+
+- `SLACK_TOKEN` - Slack token for authenticating with the incoming web hook integration

--- a/notify.py
+++ b/notify.py
@@ -7,7 +7,7 @@ SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
 class Notify(object):
     def __init__(self):
         self.active = False
-        if SLACK_WEBHOOK_URL != None:
+        if SLACK_WEBHOOK_URL != None and SLACK_WEBHOOK_URL != "":
             self.active = True
 
     def send(self, instances, action):

--- a/notify.py
+++ b/notify.py
@@ -7,7 +7,7 @@ SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
 class Notify(object):
     def __init__(self):
         self.active = False
-        if SLACK_WEBHOOK_URL != "":
+        if SLACK_WEBHOOK_URL != None:
             self.active = True
 
     def send(self, instances, action):

--- a/notify.py
+++ b/notify.py
@@ -1,0 +1,22 @@
+import requests
+import os
+
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+
+class Notify(object):
+    def __init__(self):
+        self.active = False
+        if SLACK_WEBHOOK_URL != "":
+            self.active = True
+
+    def send(self, instances, action):
+        if self.active:
+            fields = []
+            for inst in instances:
+                field = {"title": inst["name"]}
+                fields.append(field)
+
+            message = "The following instances have been %s:" % action
+            payload = {"fallback": message, "text": message, "fields": fields}
+            requests.post(SLACK_WEBHOOK_URL, json=payload)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyasn1-modules==0.0.8
 rsa==3.4.2
 six==1.10.0
 uritemplate==3.0.0
+requests==2.12.3

--- a/saver.py
+++ b/saver.py
@@ -1,5 +1,6 @@
 from oauth2client.client import GoogleCredentials
 from googleapiclient import discovery
+from notify import Notify
 
 import json
 import os
@@ -22,6 +23,7 @@ class Saver(object):
     def __init__(self):
         credentials = GoogleCredentials.get_application_default()
         self.compute = discovery.build("compute", "v1", credentials=credentials)
+        self.notify = Notify()
 
     def running_savers(self):
         result = self.compute.instances().list(project=PROJECT_ID, zone=ZONE).execute()
@@ -47,6 +49,7 @@ class Saver(object):
         instances = self.running_savers()
         print("Turning off these instances:")
         print([inst["name"] for inst in instances])
+        self.notify.send(instances, 'shutdown')
         for inst in instances:
             self.instance_off(inst)
 
@@ -54,5 +57,6 @@ class Saver(object):
         instances = self.stopped_savers()
         print("Turning on these instances:")
         print([inst["name"] for inst in instances])
+        self.notify.send(instances, 'turned on')
         for inst in instances:
             self.instance_on(inst)


### PR DESCRIPTION
* Adds `requests` as a requirement.
* Notifications are disabled unless `SLACK_WEBHOOK_URL` is defined as an envvar.
* Combines multiple servers into a single message so as not to flood the given channel.